### PR TITLE
Remove closing PHP tags

### DIFF
--- a/App/Classes/Data/User.php
+++ b/App/Classes/Data/User.php
@@ -10,4 +10,3 @@ use Core\Classes\Data as CoreData;
 
 class User extends CoreData\UserDB {
 }
-?>

--- a/App/Classes/SitePage.php
+++ b/App/Classes/SitePage.php
@@ -13,4 +13,3 @@ use Core\Classes as CoreClasses;
 
 class SitePage extends CoreClasses\CoreSitePage {
 }
-?>

--- a/App/Classes/ViewRenderers/AppViewRenderer.php
+++ b/App/Classes/ViewRenderers/AppViewRenderer.php
@@ -36,4 +36,3 @@ class AppViewRenderer extends CoreClasses\ViewRenderers\HTMLViewRenderer {
 		return false;
 	}
 }
-?>

--- a/App/Config/config.dynamic.repositories.php
+++ b/App/Config/config.dynamic.repositories.php
@@ -5,4 +5,3 @@ use Core\Classes\Configuration as CoreConfiguration;
 define('DYNAMIC_REPOSITORY_KEY', 'dynamicRepositories');
 
 $GLOBALS[DYNAMIC_REPOSITORY_KEY] = array("DynamicRepoExample"=>new CoreConfiguration\DynamicDatabaseRepositoryConfiguration('dynamic_repo_ex','id','name',null,array('name','description')));
-?>

--- a/App/Config/config.pages.php
+++ b/App/Config/config.pages.php
@@ -32,4 +32,3 @@ $sitePages = array(
 			"DynamicRepo" => new AppClasses\SitePage("dynamic repo","dynamic-repo",SECURITY_USER),
 			"users" => new AppClasses\SitePage("users","users",SECURITY_ADMIN));
 */
-?>

--- a/App/Config/config_sample.php
+++ b/App/Config/config_sample.php
@@ -115,7 +115,3 @@ define('ACTIVE_THEME','bootstrap');
 define('SECURITY_PUBLIC',-1);
 define('SECURITY_USER',0);
 define('SECURITY_ADMIN',1);
-
-?>
-
-

--- a/App/Lib/functions.php
+++ b/App/Lib/functions.php
@@ -52,4 +52,3 @@ function buildHTMLUploadForm($baseUrl,$modalContext=null,$action='upload',$subac
 			</form>';
 	return $html;
 }
-?>

--- a/App/Lib/loader.php
+++ b/App/Lib/loader.php
@@ -61,4 +61,3 @@ if (!empty($config['LOADER_CLASS'])) {
 	$logger->debug("Using Default Loader Class: CoreLoader");
 }
 $siteLoader->load();
-?>

--- a/site/dynamic-repo/index.php
+++ b/site/dynamic-repo/index.php
@@ -2,4 +2,3 @@
 include "../../App/Config/config.php";
 $controllerConfig = array('name'=>'DynamicRepo');
 include PATH_LIB."loader.php";
-?>

--- a/site/files/index.php
+++ b/site/files/index.php
@@ -2,4 +2,3 @@
 include "../../App/Config/config.php";
 $controllerConfig = array('name'=>'files');
 include PATH_LIB."loader.php";
-?>

--- a/site/index.php
+++ b/site/index.php
@@ -8,4 +8,3 @@ if (!is_file($configFile)) {
 	$controllerConfig = array('name'=>'default');
 	include PATH_LIB."loader.php";
 }
-?>

--- a/site/public.php
+++ b/site/public.php
@@ -2,4 +2,3 @@
 include "../App/Config/config.php";
 $controllerConfig = array('name'=>'default','viewName'=>'public');
 include PATH_LIB."loader.php";
-?>

--- a/site/user.php
+++ b/site/user.php
@@ -2,4 +2,3 @@
 include "../App/Config/config.php";
 $controllerConfig = array('name'=>'user');
 include PATH_LIB."loader.php";
-?>

--- a/site/users/index.php
+++ b/site/users/index.php
@@ -2,4 +2,3 @@
 include "../../App/Config/config.php";
 $controllerConfig = array('name'=>'users');
 include PATH_LIB."loader.php";
-?>

--- a/site/widgets/index.php
+++ b/site/widgets/index.php
@@ -2,4 +2,3 @@
 include "../../App/Config/config.php";
 $controllerConfig = array('name'=>'widgets');
 include PATH_LIB."loader.php";
-?>


### PR DESCRIPTION
The more recent practices are to never use closing PHP tags for pure PHP files.

This, in practice, is safer and helps prevent sending HTTP headers prematurely.
This also helps prevent random new lines, which under certain conditions, do cause problems.

This is also the recommended practice according to PHP documentation.

Maintain or ensure the existence of a newline at the end of each file.

see: https://secure.php.net/manual/en/language.basic-syntax.phptags.php