### PR TITLE
Add missing HTML close tag for tl-header.

### DIFF
--- a/App/Views/tamu/layouts/header.lo.php
+++ b/App/Views/tamu/layouts/header.lo.php
@@ -163,7 +163,7 @@ if ($controllerName != 'default' && is_file("{$config['PATH_APP']}site/resources
             </div>
         </div>
         <header class="globalHeader">
-            <tl-header page-title="<?php echo $config['APP_NAME'];?>" suppress-call-to-action="true">
+            <tl-header page-title="<?php echo $config['APP_NAME'];?>" suppress-call-to-action="true"></tl-header>
 <?php
 if ($globalUser->isLoggedIn()) {
     foreach ($pages as $controllerKey => $sitePage) {


### PR DESCRIPTION
The current use is invalid HTML and a closing tl-header (`</tl-header>`) is required.